### PR TITLE
Fix helm repo removal task by removing invalid result checks

### DIFF
--- a/roles/provider/tasks/prereqs.yml
+++ b/roles/provider/tasks/prereqs.yml
@@ -20,13 +20,7 @@
   kubernetes.core.helm_repository:
     name: akash
     state: absent
-  register: remove_result
-  failed_when: >
-    remove_result.rc != 0 and 
-    "Error: repository name (akash) not found" not in remove_result.stderr and
-    "Error: no repositories configured" not in remove_result.stderr and
-    "Error: no repo named \"akash\" found" not in remove_result.stderr
-  changed_when: remove_result.rc == 0
+  failed_when: false
 
 - name: Add required Helm repositories
   kubernetes.core.helm_repository:


### PR DESCRIPTION
The previous task incorrectly used `remove_result.rc` and `remove_result.stderr`, 
which aren't provided by the `kubernetes.core.helm_repository` module. 

Replaced that logic with `failed_when: false` to gracefully skip failure 
if the Akash repo doesn't exist, without relying on nonexistent attributes.


```
TASK [provider : Download Helm install script] ************************************************************************************
ok: [node1]
Thursday 03 April 2025  16:48:47 +0200 (0:00:01.434)       0:00:06.408 ******** 
Thursday 03 April 2025  16:48:48 +0200 (0:00:00.049)       0:00:06.458 ******** 

TASK [provider : Remove Akash Helm repository if it exists] ***********************************************************************
fatal: [node1]: FAILED! => {"changed": true, "changed_when_result": "The conditional check 'remove_result.rc == 0' failed. The error was: error while evaluating conditional (remove_result.rc == 0): 'dict object' has no attribute 'rc'. 'dict object' has no attribute 'rc'", "command": "/usr/local/bin/helm repo rm akash", "stderr": "", "stderr_lines": [], "stdout": "\"akash\" has been removed from your repositories\n", "stdout_lines": ["\"akash\" has been removed from your repositories"]}

PLAY RECAP ************************************************************************************************************************
node1                      : ok=6    changed=1    unreachable=0    failed=1    skipped=6    rescued=0    ignored=0  
```