### PR TITLE
Prevent dropping Tailscale SSH connection when running any apt commands

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Check if Tailscale update is available
+  shell: apt list --upgradable -q 2>/dev/null | grep -q "tailscale"
+  register: tailscale_update
+  changed_when: false
+  failed_when: false
+
+- name: Update apt cache and upgrade Tailscale
+  apt:
+    name: tailscale
+    state: latest
+    update_cache: yes
+  when: tailscale_update.rc == 0

--- a/roles/gpu/meta/main.yml
+++ b/roles/gpu/meta/main.yml
@@ -1,3 +1,6 @@
+dependencies:
+  - role: common
+
 galaxy_info:
   author: Vignesh V, Andrey Arapov
   description: Ansible role to configure Nvidia drives.

--- a/roles/gpu/tasks/nvidia_update.yml
+++ b/roles/gpu/tasks/nvidia_update.yml
@@ -96,7 +96,6 @@
     update_cache: yes
 
 - name: Install NVIDIA driver
-
   ansible.builtin.apt:
     name: "nvidia-driver-{{ nvidia_major_version }}"
     state: present

--- a/roles/os/meta/main.yml
+++ b/roles/os/meta/main.yml
@@ -1,3 +1,6 @@
+dependencies:
+  - role: common
+
 galaxy_info:
   author: Vignesh V
   description: Ansible role to configure sysctl and Cron jobs in Ubuntu.

--- a/roles/os/tasks/prereqs.yml
+++ b/roles/os/tasks/prereqs.yml
@@ -92,8 +92,10 @@
     state: reloaded
   when: ssh_config_updated.changed and ssh_service_name.stdout != ""
 
-- name: Install chrony
+- name: Install required packages
   ansible.builtin.apt:
-    name: chrony
+    name:
+      - tailscale
+      - chrony
     state: present
-    update_cache: yes  
+    update_cache: yes

--- a/roles/os/tasks/prereqs.yml
+++ b/roles/os/tasks/prereqs.yml
@@ -92,10 +92,8 @@
     state: reloaded
   when: ssh_config_updated.changed and ssh_service_name.stdout != ""
 
-- name: Install required packages
+- name: Install chrony
   ansible.builtin.apt:
-    name:
-      - tailscale
-      - chrony
+    name: chrony
     state: present
     update_cache: yes

--- a/roles/provider/meta/main.yml
+++ b/roles/provider/meta/main.yml
@@ -1,3 +1,6 @@
+dependencies:
+  - role: common
+
 galaxy_info:
   author: Vignesh V, Andrey Arapov
   description: Ansible role to setup Provider in Ubuntu.

--- a/roles/rook-ceph/meta/main.yml
+++ b/roles/rook-ceph/meta/main.yml
@@ -1,3 +1,6 @@
+dependencies:
+  - role: common
+
 galaxy_info:
   author: Damir Simpovic, Vignesh V, Andrey Arapov
   description: Ansible role to setup Provider in Ubuntu.

--- a/roles/tailscale/tasks/prereqs.yml
+++ b/roles/tailscale/tasks/prereqs.yml
@@ -14,12 +14,6 @@
     - not tailscale_authkey
     - not tailscale_up_skip
 
-- name: Update apt cache and install Tailscale
-  ansible.builtin.apt:
-    name: tailscale
-    update_cache: yes
-    state: present
-
 - name: Apt Dependencies
   ansible.builtin.apt:
     name: "{{ tailscale_apt_dependencies }}"

--- a/roles/tailscale/tasks/prereqs.yml
+++ b/roles/tailscale/tasks/prereqs.yml
@@ -14,6 +14,12 @@
     - not tailscale_authkey
     - not tailscale_up_skip
 
+- name: Update apt cache and install Tailscale
+  ansible.builtin.apt:
+    name: tailscale
+    update_cache: yes
+    state: present
+
 - name: Apt Dependencies
   ansible.builtin.apt:
     name: "{{ tailscale_apt_dependencies }}"


### PR DESCRIPTION
The PR should fix upgrading tailscale as upgrading tailscale restarts tailscaled which drops the current SSH connection. 

https://github.com/ovrclk/server-mgmt/issues/368
refer: https://ovrclk.slack.com/archives/C06AJ4DH6HW/p1745315347219119