### PR TITLE
fix: remove privilege escalation

### DIFF
--- a/roles/provider/tasks/init.yml
+++ b/roles/provider/tasks/init.yml
@@ -18,6 +18,7 @@
   when: control_plane_check.rc != 0
 
 - name: Fetch latest provider version from GitHub
+  become: false
   ansible.builtin.uri:
     url: https://api.github.com/repos/akash-network/provider/releases/latest
     method: GET


### PR DESCRIPTION

Encountered this error during test provider setup. The global privilege escalation setting [here](https://github.com/akash-network/provider-playbooks/blob/main/playbooks.yml#L43) is required for most tasks but causes issues for tasks that run locally on the Ansible control server.

```
TASK [provider : Fetch latest provider version from GitHub] **********************************************************
fatal: [34.60.117.188 -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error", "rc": 1}
```


### Testing
##### after disabling the privilege escalation, I can see that the tasks ran fine and the playbook execution itself completed without any errors

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/67446b00-7732-4270-a687-6cb7ef4584cd" />

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/b48674fb-ef25-468e-8212-8de92c8fd646" />

