### PR TITLE
fix: akash provider PVC pending issue

### DIFF
--- a/scripts/setup_provider.sh
+++ b/scripts/setup_provider.sh
@@ -1662,8 +1662,8 @@ else
     print_status "Note: Make sure you have a working Kubernetes cluster before proceeding"
 fi
 
-# Install local-path-provisioner for storage (required for Kubespray)
-if $SELECTED_KUBERNETES && $SELECTED_KUBESPRAY; then
+# Install local-path-provisioner for storage (only if Rook-Ceph is not selected)
+if $SELECTED_KUBERNETES && $SELECTED_KUBESPRAY && ! $SELECTED_ROOK_CEPH; then
     print_status "Installing local-path-provisioner (required by Akash provider)..."
 
     # Wait for cluster to be ready
@@ -1683,6 +1683,8 @@ if $SELECTED_KUBERNETES && $SELECTED_KUBESPRAY; then
         print_error "Failed to install local-path-provisioner - provider deployment may fail!"
         exit 1
     fi
+elif $SELECTED_KUBERNETES && $SELECTED_KUBESPRAY && $SELECTED_ROOK_CEPH; then
+    print_status "Rook-Ceph selected - skipping local-path-provisioner installation"
 elif $SELECTED_KUBERNETES && $SELECTED_K3S; then
     print_status "K3s includes local-path-provisioner by default - skipping installation"
 fi

--- a/scripts/setup_provider.sh
+++ b/scripts/setup_provider.sh
@@ -1662,6 +1662,31 @@ else
     print_status "Note: Make sure you have a working Kubernetes cluster before proceeding"
 fi
 
+# Install local-path-provisioner for storage (required for Kubespray)
+if $SELECTED_KUBERNETES && $SELECTED_KUBESPRAY; then
+    print_status "Installing local-path-provisioner (required by Akash provider)..."
+
+    # Wait for cluster to be ready
+    print_status "Waiting for Kubernetes cluster to be ready..."
+    sleep 10
+
+    # Install the provisioner
+    if kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml; then
+        print_status "local-path-provisioner installed successfully"
+
+        # Wait for it to be ready
+        print_status "Waiting for provisioner to be ready..."
+        kubectl wait --for=condition=ready pod -l app=local-path-provisioner -n local-path-storage --timeout=120s || print_warning "Timeout waiting, but continuing..."
+
+        print_status "Storage provisioner is ready"
+    else
+        print_error "Failed to install local-path-provisioner - provider deployment may fail!"
+        exit 1
+    fi
+elif $SELECTED_KUBERNETES && $SELECTED_K3S; then
+    print_status "K3s includes local-path-provisioner by default - skipping installation"
+fi
+
 # Run provider playbooks if any are selected
 if $SELECTED_OS || $SELECTED_GPU || $SELECTED_PROVIDER || $SELECTED_TAILSCALE || $SELECTED_ROOK_CEPH; then
     # Ensure we're in the provider-playbooks directory


### PR DESCRIPTION
- Install local-path-provisioner after Kubespray deployment completes

The provider Helm chart creates a StorageClass with provisioner [`rancher.io/local-path`](https://github.com/akash-network/helm-charts/pull/442/files#diff-cca300b455c36236d53700abcfffd253edbe9bec1881ddc7606cbd6a1004f004R8), but Kubespray does not include this provisioner by default unlike K3s 


test logs: https://gist.github.com/vigneshv-ocl/a9117d9f8c55ff92323e032c77379aec