### PR TITLE
feat(setup): add automatic TLS SAN, GPU/storage detection, and Rook-Ceph 1.18.7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ The setup script will guide you through selecting which playbooks to run:
 - **Tailscale**: VPN setup for secure remote access
 - **Rook-Ceph**: Storage operator installation and configuration
 
+### Tailscale + Kubernetes Integration
+
+When both Tailscale and Kubernetes are selected:
+1. The script automatically installs Tailscale on all nodes first
+2. Retrieves the Tailscale IP address from the control plane node
+3. Adds the Tailscale IP to the Kubernetes API server TLS certificate as a Subject Alternative Name (SAN)
+4. This allows secure access to the Kubernetes API through your Tailscale network
+
+This integration is automatic and requires no additional configuration.
+
 ## Manual Execution
 
 If you need to run playbooks manually:

--- a/playbooks.yml
+++ b/playbooks.yml
@@ -1,4 +1,13 @@
 ---
+- name: Tailscale Playbook
+  hosts: kube_node
+  become: true
+  become_user: root
+  roles:
+    - tailscale
+  tags:
+    - tailscale
+
 - name: k3s Playbook
   hosts: all
   become: true
@@ -12,15 +21,6 @@
     - k3s
   tags:
     - k3s
-
-- name: Tailscale Playbook
-  hosts: kube_node
-  become: true
-  become_user: root
-  roles:
-    - tailscale
-  tags:
-    - tailscale
 
 - name: OS Playbook
   hosts: kube_node
@@ -37,16 +37,6 @@
     - op
   tags:
     - op
-
-- name: Provider Playbook
-  hosts: node1
-  become: true
-  become_user: root
-  serial: "{{ serial_hosts | default(1) }}"
-  roles:
-    - provider
-  tags:
-    - provider
 
 - name: GPU Playbook
   hosts: kube_node
@@ -66,3 +56,13 @@
     - rook-ceph
   tags:
     - rook-ceph
+
+- name: Provider Playbook
+  hosts: node1
+  become: true
+  become_user: root
+  serial: "{{ serial_hosts | default(1) }}"
+  roles:
+    - provider
+  tags:
+    - provider

--- a/roles/gpu/README.md
+++ b/roles/gpu/README.md
@@ -1,27 +1,82 @@
-This ansible role covers the steps required for the installation of the GPU drivers.
+This ansible role covers the steps required for the installation of the GPU drivers following the official Akash documentation.
+
+**Documentation:** https://akash.network/docs/providers/setup-and-installation/kubespray/gpu-support/
+
+### What This Role Does
+
+1. **Installs NVIDIA Drivers** - Supports both consumer and data center GPUs
+2. **Installs NVIDIA Container Toolkit** - Required for containerized GPU workloads
+3. **Configures CDI (Container Device Interface)** - Modern device enumeration method
+4. **Creates NVIDIA RuntimeClass** - Kubernetes runtime for GPU pods
+5. **Labels GPU Nodes** - Marks nodes for GPU workload scheduling
+6. **Installs NVIDIA Device Plugin** - Exposes GPUs to Kubernetes
 
 ### Prerequisites
-- Host with GPUs
+- Host with NVIDIA GPUs
 - Access to Kubernetes Cluster
 - Kubectl binary
-- Helm binary
+- Helm binary (v3.17.3)
 - Jq binary
+- Ubuntu 24.04 LTS
 
 ### Install the requirements
-We need to install the Kubernetes core module specified in the requirements.yml file
-```
+```bash
 sudo apt install python3-kubernetes
 ansible-galaxy install -r requirements.yml
 ```
 
 ### Running the playbook
-```
-ansible-playbook playbooks.yml -e 'host=<IP>' -i inventory.yml -v
+```bash
+ansible-playbook playbooks.yml -t gpu -i inventory.yml -v
 ```
 
 ### Configuration Variables
 | Variable                 | Description                                                      | Required | Default                |
 |--------------------------|------------------------------------------------------------------|----------|------------------------|
-| `install_dir`            | usually /root/<dir>, can be any directory - used to store files  | No       | /root/ansible.tmp      |
-| `nvidia_version`         | Nvidia Driver Version                                            | No       | 570.133.20             |
-| `gpu_nodes`              | list of nodes - used to apply the gpu labels                     | No       | [node1]                |
+| `install_dir`            | Directory used to store temporary files                          | No       | /root/ansible.tmp      |
+| `nvidia_version`         | NVIDIA Driver Version                                            | No       | 580.95.05              |
+| `nvidia_driver_type`     | GPU type: "consumer" (RTX) or "datacenter" (H100)                | No       | consumer               |
+| `ubuntu_version`         | Ubuntu version for repository URLs                               | No       | 2404                   |
+| `nvdp_version`           | NVIDIA Device Plugin Helm chart version                          | No       | 0.18.0                 |
+| `cruntime_toml_path`     | Path to NVIDIA Container Runtime config                          | No       | /etc/nvidia-container-runtime/config.toml |
+
+### GPU Type Selection
+
+Set `nvidia_driver_type` in your inventory or host_vars:
+
+**Consumer GPUs** (RTX 4090, RTX 5090, etc.):
+```yaml
+nvidia_driver_type: "consumer"
+```
+
+**Data Center GPUs** (H100, H200, etc.):
+```yaml
+nvidia_driver_type: "datacenter"
+```
+
+### CDI Configuration
+
+This role configures CDI (Container Device Interface) for better security and device management:
+- Generates CDI specification at `/etc/cdi/nvidia.yaml`
+- Configures runtime at `/etc/nvidia-container-runtime/config.toml`
+- Device plugin uses `cdi-cri` strategy
+
+### Verification
+
+After installation, verify GPU functionality:
+
+```bash
+# Check NVIDIA driver
+nvidia-smi
+
+# Check device plugin pods
+kubectl -n nvidia-device-plugin get pods
+
+# Check device plugin logs
+kubectl -n nvidia-device-plugin logs -l app.kubernetes.io/instance=nvdp
+
+# Test GPU workload
+kubectl run gpu-test --rm -it --restart=Never \
+  --image=nvidia/cuda:11.6.0-base-ubuntu20.04 \
+  -- nvidia-smi
+```

--- a/roles/gpu/defaults/main.yml
+++ b/roles/gpu/defaults/main.yml
@@ -2,4 +2,7 @@
 # defaults file for GPU
 install_dir: "/root/ansible.tmp/"
 nvidia_version: 580.95.05
+nvidia_driver_type: "consumer"  # Options: "consumer" (RTX 4090, 5090, etc.) or "datacenter" (H100, H200, etc.)
 cruntime_toml_path: '/etc/nvidia-container-runtime/config.toml'
+ubuntu_version: "2404"  # Ubuntu 24.04
+nvdp_version: "0.18.0"  # NVIDIA Device Plugin version

--- a/roles/gpu/files/container-runtime-config.toml
+++ b/roles/gpu/files/container-runtime-config.toml
@@ -1,5 +1,5 @@
-accept-nvidia-visible-devices-as-volume-mounts = true
-accept-nvidia-visible-devices-envvar-when-unprivileged = false
+accept-nvidia-visible-devices-as-volume-mounts = false
+accept-nvidia-visible-devices-envvar-when-unprivileged = true
 disable-require = false
 supported-driver-capabilities = "compat32,compute,display,graphics,ngx,utility,video"
 #swarm-resource = "DOCKER_RESOURCE_GPU"

--- a/roles/gpu/tasks/nvdp.yml
+++ b/roles/gpu/tasks/nvdp.yml
@@ -55,7 +55,7 @@
           allow-nvdp: "true"
           nvidia.com/gpu.present: "true"
   delegate_to: node1
-  run_once: true
+  when: has_gpu
 
 - name: Add NVIDIA Device Plugin Helm repository
   kubernetes.core.helm_repository:
@@ -70,62 +70,87 @@
   delegate_to: node1
   run_once: true
 
-- name: Check for required GPU node labels
+- name: Check for required GPU node labels on all GPU nodes
   ansible.builtin.shell: >
-    kubectl get node {{ inventory_hostname }} -o json | jq -r '
-    {
-      "name": .metadata.name,
-      "has_allow_nvdp": (.metadata.labels."allow-nvdp" == "true"),
-    } | tostring'
-  register: node_labels_check
+    kubectl get nodes -l allow-nvdp=true -o json | jq -r '.items | length'
+  register: labeled_gpu_nodes_count
   changed_when: false
   delegate_to: node1
   run_once: true
 
-- name: Parse node label results
-  ansible.builtin.set_fact:
-    parsed_node_labels: "{{ [node_labels_check.stdout | from_json] }}"
+- name: Get total GPU nodes count
+  ansible.builtin.shell: >
+    kubectl get nodes -l nvidia.com/gpu.present=true -o json | jq -r '.items | length'
+  register: total_gpu_nodes_count
+  changed_when: false
   delegate_to: node1
   run_once: true
 
-- name: Display nodes missing required labels
+- name: Get list of labeled GPU nodes
+  ansible.builtin.shell: >
+    kubectl get nodes -l allow-nvdp=true -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+  register: labeled_nodes_list
+  changed_when: false
+  delegate_to: node1
+  run_once: true
+
+- name: Display GPU node labeling status
   ansible.builtin.debug:
-    msg: "Node {{ item.name }} missing labels: {{
-      (item.has_allow_nvdp == false) | ternary('allow-nvdp=true ', '') }}"
-  loop: "{{ parsed_node_labels }}"
-  when: not (item.has_allow_nvdp)
+    msg: |
+      GPU Node Labeling Status:
+      - Total GPU nodes: {{ total_gpu_nodes_count.stdout }}
+      - Labeled nodes: {{ labeled_gpu_nodes_count.stdout }}
+      - Nodes with allow-nvdp=true:
+      {{ labeled_nodes_list.stdout_lines | join('\n      ') if labeled_nodes_list.stdout_lines | length > 0 else '      None' }}
   delegate_to: node1
   run_once: true
 
-- name: Fail if required labels are missing
-  ansible.builtin.fail:
-    msg: "Node {{ item.name }} is missing required labels: {{
-      (item.has_allow_nvdp == false) | ternary('allow-nvdp=true ', '') }}"
-  loop: "{{ parsed_node_labels }}"
-  when: not (item.has_allow_nvdp)
-  delegate_to: node1
-  run_once: true
-
-- name: Check if any node has all required labels
+- name: Set labels_ready flag
   ansible.builtin.set_fact:
-    labels_ready: "{{ labels_ready | default(false) or (item.has_allow_nvdp) }}"
-  loop: "{{ parsed_node_labels }}"
+    labels_ready: "{{ (labeled_gpu_nodes_count.stdout | int) > 0 }}"
   delegate_to: node1
   run_once: true
 
-- name: Install NVIDIA Device Plugin
+- name: Verify all GPU nodes are labeled
+  ansible.builtin.fail:
+    msg: "Not all GPU nodes are labeled! Expected {{ total_gpu_nodes_count.stdout }} but only {{ labeled_gpu_nodes_count.stdout }} nodes have allow-nvdp=true"
+  when: labeled_gpu_nodes_count.stdout != total_gpu_nodes_count.stdout
+  delegate_to: node1
+  run_once: true
+
+- name: Install NVIDIA Device Plugin with CDI
   kubernetes.core.helm:
     name: nvdp
     chart_ref: nvdp/nvidia-device-plugin
     release_namespace: nvidia-device-plugin
     create_namespace: true
-    chart_version: 0.17.1
+    chart_version: "{{ nvdp_version }}"
     values:
       runtimeClassName: nvidia
-      deviceListStrategy: volume-mounts
+      deviceListStrategy: cdi-cri
+      nvidiaDriverRoot: "/"
       nodeSelector:
         allow-nvdp: "true"
     state: present
   when: labels_ready | bool
   delegate_to: node1
   run_once: true
+
+- name: Wait for NVIDIA Device Plugin pods to be ready
+  ansible.builtin.command: kubectl -n nvidia-device-plugin wait --for=condition=ready pod -l app.kubernetes.io/instance=nvdp --timeout=300s
+  delegate_to: node1
+  run_once: true
+  register: nvdp_wait
+  changed_when: false
+  failed_when: false
+
+- name: Get NVIDIA Device Plugin logs
+  ansible.builtin.command: kubectl -n nvidia-device-plugin logs -l app.kubernetes.io/instance=nvdp --tail=50
+  delegate_to: node1
+  run_once: true
+  register: nvdp_logs
+  changed_when: false
+
+- name: Display NVIDIA Device Plugin logs
+  ansible.builtin.debug:
+    msg: "{{ nvdp_logs.stdout_lines }}"

--- a/roles/gpu/tasks/nvidia_ctoolkit.yml
+++ b/roles/gpu/tasks/nvidia_ctoolkit.yml
@@ -1,4 +1,17 @@
 ---
+# STEP 3 - Configure NVIDIA CDI (Container Device Interface)
+- name: Create CDI directory
+  ansible.builtin.file:
+    path: /etc/cdi
+    state: directory
+    mode: '0755'
+
+- name: Generate NVIDIA CDI specification
+  ansible.builtin.command: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+  args:
+    creates: /etc/cdi/nvidia.yaml
+  register: cdi_generate
+
 - name: Check if NVIDIA runtime configuration file exists
   ansible.builtin.stat:
     path: "{{ cruntime_toml_path }}"
@@ -14,34 +27,33 @@
     src: "{{ cruntime_toml_path }}"
     dest: "{{ cruntime_toml_path }}_bk"
     remote_src: yes
-  when: not backup_stat.stat.exists
+  when: nvidia_config_file.stat.exists and not backup_stat.stat.exists
 
-- name: Copy the container runtime config file
-  ansible.builtin.copy:
-    src: container-runtime-config.toml
-    dest: "{{ cruntime_toml_path }}"
+- name: Ensure NVIDIA Container Runtime config directory exists
+  ansible.builtin.file:
+    path: /etc/nvidia-container-runtime
+    state: directory
+    mode: '0755'
 
-- name: Check if nvidia parameters are present in config.toml
-  ansible.builtin.shell: |
-    result1=$(grep -E "^accept-nvidia-visible-devices-as-volume-mounts = true" {{ cruntime_toml_path }} > /dev/null; echo $?)
-    result2=$(grep -E "^accept-nvidia-visible-devices-envvar-when-unprivileged = false" {{ cruntime_toml_path }} > /dev/null; echo $?)
-    echo "{\"volume_param\": $result1, \"envvar_param\": $result2}"
-  register: nvidia_params_check
+- name: Configure NVIDIA Container Runtime for CDI
+  ansible.builtin.lineinfile:
+    path: "{{ cruntime_toml_path }}"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    create: yes
+    mode: '0644'
+  loop:
+    - regexp: '^#?\s*accept-nvidia-visible-devices-as-volume-mounts\s*='
+      line: 'accept-nvidia-visible-devices-as-volume-mounts = false'
+    - regexp: '^#?\s*accept-nvidia-visible-devices-envvar-when-unprivileged\s*='
+      line: 'accept-nvidia-visible-devices-envvar-when-unprivileged = true'
+
+- name: Verify CDI configuration
+  ansible.builtin.command: grep -E "accept-nvidia-visible-devices" {{ cruntime_toml_path }}
+  register: cdi_config_check
   changed_when: false
+  failed_when: false
 
-- name: Set facts about nvidia parameters
-  ansible.builtin.set_fact:
-    nvidia_volume_param_present: "{{ (nvidia_params_check.stdout | from_json).volume_param == 0 }}"
-    nvidia_envvar_param_present: "{{ (nvidia_params_check.stdout | from_json).envvar_param == 0 }}"
-
-- name: Fail if nvidia parameters are missing
-  ansible.builtin.fail:
-    msg: >
-      Missing required NVIDIA parameters in {{ cruntime_toml_path }}:
-      {% if not nvidia_volume_param_present %}
-      - accept-nvidia-visible-devices-as-volume-mounts = true
-      {% endif %}
-      {% if not nvidia_envvar_param_present %}
-      - accept-nvidia-visible-devices-envvar-when-unprivileged = false
-      {% endif %}
-  when: not (nvidia_volume_param_present and nvidia_envvar_param_present)
+- name: Display CDI configuration
+  ansible.builtin.debug:
+    msg: "{{ cdi_config_check.stdout_lines }}"

--- a/roles/gpu/tasks/nvidia_update.yml
+++ b/roles/gpu/tasks/nvidia_update.yml
@@ -71,22 +71,27 @@
     state: present
     keyring: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
 
-- name: Download CUDA key
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download CUDA GPG key
   ansible.builtin.get_url:
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{{ ubuntu_version }}/x86_64/3bf863cc.pub
     dest: /tmp/cuda-key.pub
     mode: '0644'
 
 - name: Add CUDA key to keyring
   ansible.builtin.shell: |
-    mkdir -p /usr/share/keyrings
-    gpg --dearmor -o /usr/share/keyrings/cuda-keyring.gpg /tmp/cuda-key.pub
+    gpg --dearmor -o /etc/apt/keyrings/nvidia-cuda.gpg /tmp/cuda-key.pub
   args:
-    creates: /usr/share/keyrings/cuda-keyring.gpg
+    creates: /etc/apt/keyrings/nvidia-cuda.gpg
 
 - name: Add NVIDIA CUDA repository
   ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/cuda-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64 /"
+    repo: "deb [signed-by=/etc/apt/keyrings/nvidia-cuda.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{{ ubuntu_version }}/x86_64/ /"
     state: present
     filename: cuda-repo
     update_cache: yes
@@ -95,7 +100,7 @@
   ansible.builtin.apt:
     update_cache: yes
 
-- name: Install NVIDIA driver
+- name: Install NVIDIA driver (consumer GPUs)
   ansible.builtin.apt:
     name: "nvidia-driver-{{ nvidia_major_version }}"
     state: present
@@ -103,33 +108,28 @@
     dpkg_options: 'force-confdef,force-confold'
   environment:
     DEBIAN_FRONTEND: noninteractive
+  when: nvidia_driver_type == "consumer"
 
-- name: Install NVIDIA CUDA toolkit
-  ansible.builtin.apt:
-    name: nvidia-cuda-toolkit
-    state: present
-    update_cache: yes
+- name: Install NVIDIA driver and Fabric Manager (data center GPUs)
+  block:
+    - name: Install NVIDIA server driver
+      ansible.builtin.apt:
+        name: "nvidia-driver-{{ nvidia_major_version }}-server"
+        state: present
+        update_cache: yes
+        dpkg_options: 'force-confdef,force-confold'
+      environment:
+        DEBIAN_FRONTEND: noninteractive
 
-- name: Check if NVIDIA GPUs are PCIe
-  ansible.builtin.shell: nvidia-smi -L
-  register: nvidia_smi_output
-  changed_when: false
+    - name: Install NVIDIA Fabric Manager
+      ansible.builtin.apt:
+        name: "nvidia-fabricmanager-{{ nvidia_major_version }}"
+        state: present
+        update_cache: yes
 
-- name: Fail if the Nvidia GPUs are not initialized
-  ansible.builtin.set_fact: 
-    has_passed: "{{ 'Failed to initialize' in nvidia_smi_output.stdout }}"
-
-- name: Set fact for PCIe GPUs
-  ansible.builtin.set_fact:
-    has_pcie: "{{ 'PCIe' in nvidia_smi_output.stdout }}"  
-
-- name: Install and configure NVIDIA Fabric Manager
-  ansible.builtin.apt:
-    name: "nvidia-fabricmanager-{{ nvidia_major_version }}"
-    state: present
-    update_cache: yes
-  when: 
-  - has_pcie is none
-  - has_passed
-  notify:
-    - Configure NVIDIA Fabric Manager
+    - name: Start NVIDIA Fabric Manager
+      ansible.builtin.systemd:
+        name: nvidia-fabricmanager
+        state: started
+        enabled: yes
+  when: nvidia_driver_type == "datacenter"

--- a/roles/k3s/README.md
+++ b/roles/k3s/README.md
@@ -26,3 +26,23 @@ ansible-playbook -i inventory.yml playbook.yml -t k3s -e 'host=workers'
 | `scheduler_config_path`   | Path to scheduler configuration                | No       | Generated from data_dir |
 | `tls_san`                 | TLS SAN for the K3s API server                 | No       | First control plane host|
 
+#### TLS SAN Configuration
+The `tls_san` variable allows you to add additional IP addresses or hostnames to the Kubernetes API server TLS certificate. This is useful for accessing the cluster through VPNs (like Tailscale) or load balancers.
+
+When using the `setup_provider.sh` script:
+- If Tailscale is selected, the script automatically installs Tailscale on the control plane node first
+- It retrieves the Tailscale IP address and configures it as the TLS SAN
+- This allows you to access the Kubernetes API server securely through your Tailscale network
+
+You can also manually set a custom TLS SAN by adding it to your host_vars file:
+```yaml
+tls_san: "100.64.0.1"  # Your custom IP or hostname
+```
+
+
+
+
+UUID=b4b63d1a-2833-491c-b84c-d4c1e529a12c /data ext4 defaults 0 2
+UUID=fa6f82eb-9464-4322-abef-a20b7597b44e /data ext4 defaults 0 2
+UUID=e5ea5f8e-95a0-4fdc-bd9c-bdf40ba20cd4 /data ext4 defaults 0 2
+UUID=413d4644-2760-4035-9751-70302246d3fc /data ext4 defaults 0 2

--- a/roles/provider/tasks/detect_capabilities.yml
+++ b/roles/provider/tasks/detect_capabilities.yml
@@ -1,0 +1,100 @@
+---
+# Detect Rook-Ceph Persistent Storage
+- name: Check for storage class with akash.network label
+  kubernetes.core.k8s_info:
+    kind: StorageClass
+    label_selectors:
+      - akash.network=true
+  register: akash_storage_classes
+  failed_when: false
+
+- name: Set persistent storage facts
+  ansible.builtin.set_fact:
+    has_persistent_storage: true
+    storage_class_name: "{{ akash_storage_classes.resources[0].metadata.name }}"
+  when:
+    - akash_storage_classes.resources is defined
+    - akash_storage_classes.resources | length > 0
+
+- name: Display persistent storage detection result
+  ansible.builtin.debug:
+    msg: "{{ 'Persistent storage detected: ' + storage_class_name if has_persistent_storage | default(false) else 'Persistent storage: Not configured' }}"
+
+# Process GPU information for Akash attributes
+# gpu_detect.yml already ran and set gpu_nodes if GPUs are present
+- name: Parse GPU model information for Akash attributes
+  ansible.builtin.set_fact:
+    gpu_model_raw: "{{ gpu_nodes[0].split(',')[1] | trim }}"
+    gpu_memory_mib: "{{ gpu_nodes[0].split(',')[2] | trim | regex_replace(' MiB', '') }}"
+  when:
+    - has_gpu | default(false)
+    - gpu_nodes is defined
+    - gpu_nodes | length > 0
+
+- name: Format GPU model name for Akash (lowercase, no spaces/special chars)
+  ansible.builtin.set_fact:
+    gpu_model_name: "{{ gpu_model_raw | lower | regex_replace('nvidia ', '') | regex_replace('geforce ', '') | regex_replace('[^a-z0-9]', '') }}"
+    gpu_memory_gi: "{{ (gpu_memory_mib | int / 1024) | round(0, 'floor') | int }}Gi"
+  when:
+    - gpu_model_raw is defined
+    - gpu_memory_mib is defined
+
+- name: Detect GPU interface type (PCIe vs SXM)
+  ansible.builtin.shell: nvidia-smi --query-gpu=pci.bus_id --format=csv,noheader | head -1
+  register: gpu_bus_id
+  changed_when: false
+  failed_when: false
+  when: has_gpu | default(false)
+
+- name: Set GPU interface type
+  ansible.builtin.set_fact:
+    gpu_interface: "{{ 'sxm' if 'SXM' in gpu_bus_id.stdout | default('') or gpu_model_name is search('h100|h200|a100') else 'pcie' }}"
+  when:
+    - has_gpu | default(false)
+    - gpu_model_name is defined
+
+- name: Display GPU attributes for Akash
+  ansible.builtin.debug:
+    msg: |
+      GPU Attributes for Akash Provider:
+      - Model: {{ gpu_model_name | default('Not detected') }}
+      - Memory: {{ gpu_memory_gi | default('Not detected') }}
+      - Interface: {{ gpu_interface | default('Not detected') }}
+      - CUDA Version: {{ cuda_version | default('Not detected') }}
+      - SHM Support: Enabled (capabilities/storage/2/class: ram)
+  when: has_gpu | default(false)
+
+- name: Display complete capability summary
+  ansible.builtin.debug:
+    msg: |
+      Akash Provider Capabilities Summary:
+      =====================================
+      Storage Classes:
+      {% if has_persistent_storage | default(false) %}
+        - Persistent: {{ storage_class_name }}
+      {% endif %}
+      {% if has_gpu | default(false) %}
+        - SHM (RAM): Enabled for GPU workloads
+      {% endif %}
+      {% if not has_persistent_storage | default(false) and not has_gpu | default(false) %}
+        - Default (local-path) only
+      {% endif %}
+      
+      GPU Support:
+      {% if has_gpu | default(false) %}
+        - Model: {{ gpu_model_name }}
+        - Memory: {{ gpu_memory_gi }}
+        - Interface: {{ gpu_interface }}
+        - CUDA: {{ cuda_version | default('Unknown') }}
+      {% else %}
+        - Not configured
+      {% endif %}
+      
+      Inventory Operator Storage Classes:
+        - default
+      {% if has_persistent_storage | default(false) %}
+        - {{ storage_class_name }}
+      {% endif %}
+      {% if has_gpu | default(false) %}
+        - ram
+      {% endif %}

--- a/roles/provider/tasks/install.yml
+++ b/roles/provider/tasks/install.yml
@@ -17,18 +17,44 @@
       labels:
         akash.network: 'true'
 
-- name: Install Akash Helm charts
+- name: Install Akash hostname-operator
   kubernetes.core.helm:
-    name: "{{ item.name }}"
-    chart_ref: "akash/{{ item.chart }}"
+    name: akash-hostname-operator
+    chart_ref: akash/akash-hostname-operator
     release_namespace: akash-services
-  loop:
-    - name: akash-hostname-operator
-      chart: akash-hostname-operator
-    - name: inventory-operator
-      chart: akash-inventory-operator
-    - name: akash-node
-      chart: akash-node
+
+- name: Build inventory operator storage classes list
+  ansible.builtin.set_fact:
+    inventory_storage_classes: "{{ ['default'] }}"
+
+- name: Add persistent storage class to inventory operator
+  ansible.builtin.set_fact:
+    inventory_storage_classes: "{{ inventory_storage_classes + [storage_class_name] }}"
+  when: has_persistent_storage | default(false)
+
+- name: Add RAM storage class for GPU workloads
+  ansible.builtin.set_fact:
+    inventory_storage_classes: "{{ inventory_storage_classes + ['ram'] }}"
+  when: has_gpu | default(false)
+
+- name: Display inventory operator storage configuration
+  ansible.builtin.debug:
+    msg: "Inventory operator will be configured with storage classes: {{ inventory_storage_classes | join(', ') }}"
+
+- name: Install Akash inventory-operator with storage classes
+  kubernetes.core.helm:
+    name: inventory-operator
+    chart_ref: akash/akash-inventory-operator
+    release_namespace: akash-services
+    values:
+      inventoryConfig:
+        cluster_storage: "{{ inventory_storage_classes }}"
+
+- name: Install Akash node
+  kubernetes.core.helm:
+    name: akash-node
+    chart_ref: akash/akash-node
+    release_namespace: akash-services
 
 - name: Apply Akash CRD from URL
   kubernetes.core.k8s:

--- a/roles/provider/tasks/main.yml
+++ b/roles/provider/tasks/main.yml
@@ -9,6 +9,9 @@
 - name: Detect GPU and CUDA information
   ansible.builtin.import_tasks: gpu_detect.yml
 
+- name: Detect available capabilities (storage, GPU, etc.)
+  ansible.builtin.import_tasks: detect_capabilities.yml
+
 - name: Initialize the Akash charts
   ansible.builtin.import_tasks: install.yml
 

--- a/roles/provider/templates/provider.yaml.j2
+++ b/roles/provider/templates/provider.yaml.j2
@@ -20,6 +20,26 @@ attributes:
   - key: cuda-version
     value: "{{ cuda_version }}"
 {% endif %}
+{% if has_persistent_storage | default(false) and storage_class_name is defined %}
+  - key: capabilities/storage/1/class
+    value: "{{ storage_class_name }}"
+  - key: capabilities/storage/1/persistent
+    value: "true"
+{% endif %}
+{% if has_gpu | default(false) and gpu_model_name is defined %}
+  - key: capabilities/gpu/vendor/nvidia/model/{{ gpu_model_name }}
+    value: "true"
+  - key: capabilities/gpu/vendor/nvidia/model/{{ gpu_model_name }}/ram/{{ gpu_memory_gi }}
+    value: "true"
+  - key: capabilities/gpu/vendor/nvidia/model/{{ gpu_model_name }}/interface/{{ gpu_interface }}
+    value: "true"
+  - key: capabilities/gpu/vendor/nvidia/model/{{ gpu_model_name }}/interface/{{ gpu_interface }}/ram/{{ gpu_memory_gi }}
+    value: "true"
+  - key: capabilities/storage/2/class
+    value: ram
+  - key: capabilities/storage/2/persistent
+    value: "false"
+{% endif %}
 {% if country is defined and country %}
   - key: country
     value: "{{ country }}"

--- a/roles/rook-ceph/README.md
+++ b/roles/rook-ceph/README.md
@@ -1,30 +1,156 @@
-The rook-ceph installation playbook.
+# Rook-Ceph Role
 
-It will install the complete rook-ceph operator, the rook-ceph cluster and will do the finalizing tasks like labeling the storage class.
+This role deploys Rook-Ceph for persistent storage on Akash providers following the official Akash documentation.
 
-## HOW TO USE:
-1. Install helm: `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`
-2. run `./generate-rook-ceph-cluster-config.sh`
-3. `cd ~/kubespray`
-4. run the playbook using `ansible-playbook -i inventory/akash/hosts.yaml -b -v --private-key=~/.ssh/id_rsa cluster.yml -e 'host=all' -t rook-ceph`
+**Documentation:** https://akash.network/docs/providers/setup-and-installation/kubespray/persistent-storage/
 
-#### Configuration Variables
+## What This Role Does
 
+1. **Installs Rook-Ceph Operator** (v1.18.7)
+2. **Deploys Ceph Cluster** with your storage configuration
+3. **Creates Storage Class** (beta1/beta2/beta3)
+4. **Labels Storage Class** with `akash.network=true` for Akash detection
+5. **Creates /root/provider directory** for provider configuration
+
+## Prerequisites
+
+### Hardware Requirements
+
+**Minimum Requirements:**
+- 4 SSDs across all nodes, OR
+- 2 NVMe SSDs across all nodes
+
+**Drive Requirements:**
+- Dedicated exclusively to persistent storage
+- Unformatted (no partitions or filesystems)
+- NOT used for OS or ephemeral storage
+
+### Network Requirements
+
+- **Minimum:** 10 GbE NIC cards for storage nodes
+- **Recommended:** 25 GbE or faster
+
+### Ceph Requirements
+
+For production:
+- **Minimum 3 OSDs** for redundancy
+- **Minimum 2 Ceph managers**
+- **Minimum 3 Ceph monitors**
+- **Minimum 60 GB** disk space at `/var/lib/ceph/`
+
+**OSDs per drive:**
+- HDD: 1 OSD max
+- SSD: 1 OSD max
+- NVMe: 2 OSDs max
+
+## Configuration Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `rook_ceph_namespace` | Namespace for Rook Ceph | `rook-ceph` |
+| `rook_ceph_version` | Rook Ceph version | `1.18.7` |
+| `pool_size` | Number of replicas | `3` |
+| `min_size` | Minimum replicas | `2` |
+| `mon_count` | Ceph monitor count | `3` |
+| `mgr_count` | Ceph manager count | `2` |
+| `device_filter` | Device filter (e.g., `sd*`, `nvme*`) | `sd*` |
+| `device_type` | Device type: `hdd`, `ssd`, or `nvme` | `ssd` |
+| `osds_per_device` | OSDs per device (1 for HDD/SSD, 2 for NVMe) | `1` |
+| `failure_domain` | Failure domain (`host` or `osd`) | `host` |
+| `storage_class` | Storage class name (`beta1`, `beta2`, or `beta3`) | `beta2` |
+| `kubelet_dir_path` | Kubelet root directory | `/var/lib/kubelet` |
+| `rook_ceph_data_dir` | Ceph data directory | `/var/lib/rook` |
+| `storage_nodes` | List of storage node names | `[]` |
+
+## Storage Class Types
+
+| Class | Description | Device Type | OSDs per Device |
+|-------|-------------|-------------|-----------------|
+| `beta1` | HDD storage | HDD | 1 |
+| `beta2` | SSD storage | SSD | 1 |
+| `beta3` | NVMe storage | NVMe | 1-2 |
+
+## Directory Paths
+
+### kubelet_dir_path
+- Must match Kubernetes kubelet `--root-dir` configuration
+- Default: `/var/lib/kubelet`
+- Custom: `/data/kubelet` (if configured during K8s setup)
+
+### rook_ceph_data_dir
+- Where Ceph monitor and manager data is stored (NOT OSD data)
+- Default: `/var/lib/rook`
+- Custom: `/data/rook` (if using RAID array at `/data`)
+
+## Usage
+
+The setup script (`scripts/setup_provider.sh`) automatically configures all these variables based on your input. 
+
+### Manual Playbook Execution
+
+```bash
+ansible-playbook -i inventory.yml playbooks.yml -t rook-ceph -v \
+  --extra-vars "kubelet_dir_path=/var/lib/kubelet"
 ```
-| Variable                  | Description                                    | Required | Default                 |
-|---------------------------|------------------------------------------------|----------|-------------------------|
-| `rook_ceph_namespace`     | Namespace for Rook Ceph deployment             | No       | rook-ceph               |
-| `rook_ceph_version`       | Version of Rook Ceph to install                | No       | 1.16.6                  |
-| `pool_size`               | Number of replicas for Ceph pools              | No       | 3                       |
-| `min_size`                | Minimum number of replicas for pools           | No       | 2                       |
-| `mon_count`               | Number of Ceph monitor daemons                 | No       | 3                       |
-| `mgr_count`               | Number of Ceph manager daemons                 | No       | 2                       |
-| `device_filter`           | Device filter pattern for OSDs                 | No       | sd*                     |
-| `device_type`             | Device type used for OSDs                      | No       | ssd                     |
-| `osds_per_device`         | Number of OSDs per device                      | No       | 1                       |
-| `failure_domain`          | Failure domain for data placement              | No       | host                    |
-| `storage_class`           | Default storage class name                     | No       | rook-ceph-block         |
-| `zfs_for_ephemeral`       | Use ZFS for ephemeral storage                  | No       | false                   |
-| `kubelet_dir_path`        | Directory for kubelet data                     | No       | /var/lib/kubelet        |
-| `storage_nodes`           | List of nodes designated for storage           | No       | []                      |
+
+## Verification
+
+After installation, verify:
+
+```bash
+# Check cluster status
+kubectl -n rook-ceph get cephcluster
+
+# Check storage class
+kubectl get storageclass
+
+# Verify label
+kubectl get sc <storage-class> --show-labels
 ```
+
+Expected output:
+- Ceph cluster: `PHASE: Ready`, `HEALTH: HEALTH_OK`
+- Storage class labeled with `akash.network=true`
+
+## Troubleshooting
+
+### Check Operator Logs
+```bash
+kubectl -n rook-ceph logs -l app=rook-ceph-operator
+```
+
+### Check Ceph Status
+```bash
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph status
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd tree
+```
+
+### Common Issues
+
+**OSDs not starting:**
+- Verify drives are unformatted: `lsblk -f`
+- Check deviceFilter matches your drives
+- Review OSD pod logs
+
+**HEALTH_WARN:**
+- Check `ceph status` for specific warnings
+- Initial warnings during setup are normal
+
+## Integration with Provider Role
+
+The provider role will automatically:
+1. Detect the labeled storage class
+2. Add storage attributes to `provider.yaml`:
+   ```yaml
+   - key: capabilities/storage/1/class
+     value: beta2  # (or beta1/beta3)
+   - key: capabilities/storage/1/persistent
+     value: "true"
+   ```
+3. Configure inventory-operator with the storage class
+
+## Additional Resources
+
+- [Rook Documentation](https://rook.io/docs/rook/latest-release/)
+- [Ceph Documentation](https://docs.ceph.com/)
+- [Akash Persistent Storage Guide](https://akash.network/docs/providers/setup-and-installation/kubespray/persistent-storage/)

--- a/roles/rook-ceph/defaults/main.yaml
+++ b/roles/rook-ceph/defaults/main.yaml
@@ -1,5 +1,5 @@
 rook_ceph_namespace: rook-ceph
-rook_ceph_version: "1.16.6"
+rook_ceph_version: "1.18.7"
 
 # Ceph cluster configuration
 pool_size: 3
@@ -14,11 +14,17 @@ osds_per_device: 1
 failure_domain: "host"
 storage_class: "beta2"
 zfs_for_ephemeral: "false"
-# Kubelet directory path
-# This must match the kubelet's --root-dir configuration
-# Leave empty to use k3s default (/var/lib/kubelet)
+
+# Directory paths
+# Kubelet directory path - must match kubelet's --root-dir configuration
+# Leave empty to use default (/var/lib/kubelet)
 # Set to /data/kubelet if using custom kubelet root dir
 kubelet_dir_path: ""
+
+# Ceph data directory path - where Ceph monitor and manager data is stored
+# Default: /var/lib/rook
+# If using custom mount (e.g., /data), set to /data/rook
+rook_ceph_data_dir: "/var/lib/rook"
 
 # Node configuration (will be set by setup_provider.sh)
 storage_nodes: []

--- a/roles/rook-ceph/generate-rook-ceph-cluster-config.sh
+++ b/roles/rook-ceph/generate-rook-ceph-cluster-config.sh
@@ -48,7 +48,7 @@ kubelet_dir_path=${kubelet_dir_path:-/var/lib/kubelet}
 # Write to rook-ceph-defaults.yml
 cat > rook-ceph-defaults.yml << EOF
 rook_ceph_namespace: rook-ceph
-rook_ceph_version: "1.16.6"
+rook_ceph_version: "1.18.7"
 
 ceph_cluster:
   storage_hosts:

--- a/roles/rook-ceph/tasks/rook_ceph_cluster.yaml
+++ b/roles/rook-ceph/tasks/rook_ceph_cluster.yaml
@@ -1,7 +1,13 @@
+- name: Create rook-ceph directory
+  ansible.builtin.file:
+    path: /root/rook-ceph
+    state: directory
+    mode: '0755'
+
 - name: Copy rook-ceph values file to remote host
   template:
     src: "rook-ceph-cluster.values.yml.j2"
-    dest: "/root/provider/rook-ceph-cluster.values.yml"
+    dest: "/root/rook-ceph/rook-ceph-cluster.values.yml"
 
 - name: Install Rook-Ceph Cluster via Helm
   kubernetes.core.helm:
@@ -10,5 +16,5 @@
     release_namespace: "{{ rook_ceph_namespace }}"
     chart_version: "{{ rook_ceph_version }}"
     values_files:
-      - /root/provider/rook-ceph-cluster.values.yml
+      - /root/rook-ceph/rook-ceph-cluster.values.yml
     state: present

--- a/roles/rook-ceph/tasks/rook_ceph_finalize.yaml
+++ b/roles/rook-ceph/tasks/rook_ceph_finalize.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Read rook-ceph values from target node
   ansible.builtin.slurp:
-    src: /root/provider/rook-ceph-cluster.values.yml
+    src: /root/rook-ceph/rook-ceph-cluster.values.yml
   register: rook_ceph_values_file
 
 - name: Load rook-ceph values from file
@@ -33,13 +33,11 @@
     name: rbd
     state: present
 
-- name: Remove old capability keys from provider.yaml
-  ansible.builtin.replace:
-    path: ~/provider/provider.yaml
-    regexp: '^\s*- key: (feat-persistent-storage|capabilities/storage/1/class|capabilities/storage/1/persistent)\n\s*value: .*$'
-    replace: ''
-  vars:
-    ansible_python_interpreter: /usr/bin/python3  # ensure consistent behavior if needed
+- name: Create /root/provider directory for provider configuration
+  ansible.builtin.file:
+    path: /root/provider
+    state: directory
+    mode: '0755'
 
 - name: Extract storage class name from rook-ceph-cluster.values.yml
   ansible.builtin.set_fact:
@@ -50,15 +48,6 @@
         | map(attribute='storageClass.name')
         | list | first }}
 
-- name: Append updated capability entries to provider.yaml
-  ansible.builtin.blockinfile:
-    path: ~/provider/provider.yaml
-    block: |
-      - key: feat-persistent-storage
-        value: true
-      - key: capabilities/storage/1/class
-        value: {{ storage_class_name }}
-      - key: capabilities/storage/1/persistent
-        value: true
-    marker: "# {mark} akash-capabilities"
-    insertafter: EOF
+- name: Display storage class configuration
+  ansible.builtin.debug:
+    msg: "Rook-Ceph storage class '{{ storage_class_name }}' is configured and will be detected by provider role"

--- a/roles/rook-ceph/templates/rook-ceph-cluster.values.yml.j2
+++ b/roles/rook-ceph/templates/rook-ceph-cluster.values.yml.j2
@@ -24,8 +24,6 @@ cephClusterSpec:
 {% set nodes = storage_nodes | replace('[', '') | replace(']', '') | replace("'", '') | trim() %}
 {% for node in nodes.split() %}
     - name: "{{ node }}"
-      config:
-        storeType: "{{ 'bluestore' if device_type == 'ssd' or device_type == 'nvme' else 'filestore' }}"
 {% endfor %}
 cephBlockPools:
   - name: akash-deployments


### PR DESCRIPTION
- Add automatic Tailscale IP integration for K8s/K3s API server TLS certificates
- Implement automatic GPU capability detection with new Akash attribute format
- Add SHM (shared memory) storage support for GPU workloads
- Update Rook-Ceph to v1.18.7 following official Akash documentation
- Add automatic storage class detection for persistent storage capabilities
- Configure inventory operator dynamically based on available capabilities
- Fix kubelet_dir_path configuration for custom storage mounts
- Update GPU role to support CDI and consumer vs datacenter GPU types
- Reorder playbook execution: Tailscale → K3s → Rook-Ceph → Provider
- Fix GPU node labeling to apply to all GPU nodes (removed run_once)
- Update all component versions and configurations per Akash docs

BREAKING CHANGE: Rook-Ceph Helm release name changed to rook-ceph-operator